### PR TITLE
Pubsub support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,6 @@ Appllication configuration options
 ``REDIS_PASSWORD`` -- Connection password (None)
 ``REDIS_POOLSIZE`` -- Connection pool size (1)
 ``REDIS_FAKE``     -- Use fake redis instead real one for tests proposals (False)
-``REDIS_PUBSUB``   -- Enable PubSub subscription - this will create one separate connection for that purpose (True)
 
 Queries
 -------

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Queries
 Pub/Sub
 -------
 
-Sending is done like this:
+Publishing messages is as simple as this:
 
 ::
 
@@ -120,6 +120,9 @@ so in Python 3.5+ that can be spelled in lighter way:
     # no need to close connection explicitly
     # as it will be done automatically by context manager.
 
+It might be not very good to create separate Redis connection per each subscription manager
+(e.g. per each websocket), so that could be improved by managing subscribed channel masks
+and reusing the same single "pubsub-specific" redis connection.
 
 .. _bugtracker:
 

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Queries
 
     @app.register
     def view(request):
-        value = yield from app.redis.get('my_key')
+        value = yield from app.ps.redis.get('my_key')
         return value
 
 

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ Appllication configuration options
 ``REDIS_PASSWORD`` -- Connection password (None)
 ``REDIS_POOLSIZE`` -- Connection pool size (1)
 ``REDIS_FAKE``     -- Use fake redis instead real one for tests proposals (False)
+``REDIS_PUBSUB``   -- Enable PubSub subscription - this will create one separate connection for that purpose (True)
 
 Queries
 -------

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ Then you open a separate connection within that manager,
 after which you can subscribe and listen for messages:
 
 ::
+
     sub = app.ps.redis.start_subscribe()
     yield from sub.open() # this creates separate connection to redis
     # sub.open() returns that manager itself, so this can be written like this:
@@ -112,6 +113,7 @@ Subscription manager also implements PEP 0492 `async with` and `async for` inter
 so in Python 3.5+ that can be spelled in lighter way:
 
 ::
+
     async with app.ps.redis.start_subscribe() as sub:
         sub.subscribe(['channel1'])
         sub.psubscribe(['channel.a.*', 'channel.b.*']) # you can use masks as well

--- a/muffin_redis.py
+++ b/muffin_redis.py
@@ -49,22 +49,19 @@ class Plugin(BasePlugin):
 
             self.conn = yield from FakeConnection.create()
 
-        elif self.cfg.poolsize == 1:
-            try:
-                self.conn = yield from asyncio.wait_for(asyncio_redis.Connection.create(
-                                host=self.cfg.host, port=self.cfg.port,
-                                password=self.cfg.password, db=self.cfg.db,
-                            ), self.cfg.timeout)
-            except asyncio.TimeoutError:
-                raise PluginException('Muffin-redis connection timeout.')
-
         else:
             try:
-                self.conn = yield from asyncio.wait_for(asyncio_redis.Pool.create(
-                    host=self.cfg.host, port=self.cfg.port,
-                    password=self.cfg.password, db=self.cfg.db,
-                    poolsize=self.cfg.poolsize,
-                ), self.cfg.timeout)
+                if self.cfg.poolsize == 1:
+                    self.conn = yield from asyncio.wait_for(asyncio_redis.Connection.create(
+                                    host=self.cfg.host, port=self.cfg.port,
+                                    password=self.cfg.password, db=self.cfg.db,
+                                ), self.cfg.timeout)
+                else:
+                    self.conn = yield from asyncio.wait_for(asyncio_redis.Pool.create(
+                        host=self.cfg.host, port=self.cfg.port,
+                        password=self.cfg.password, db=self.cfg.db,
+                        poolsize=self.cfg.poolsize,
+                    ), self.cfg.timeout)
             except asyncio.TimeoutError:
                 raise PluginException('Muffin-redis connection timeout.')
 

--- a/muffin_redis.py
+++ b/muffin_redis.py
@@ -139,7 +139,7 @@ class Subscription():
         """
         if not self._conn:
             raise ValueError('Was not connected')
-        yield from self._conn.close()
+        self._conn.close()
     @asyncio.coroutine
     def __aexit__(self, exc_type, exc, tb):
         yield from self.close()

--- a/muffin_redis.py
+++ b/muffin_redis.py
@@ -167,10 +167,10 @@ class Subscription():
             key = channel, is_mask
             self._channels.append(key)
             if key in self._plugin._subscriptions:
+                self._plugin._subscriptions[key].append(self)
+            else:
                 self._plugin._subscriptions[key] = [self]
                 news.append(channel)
-            else:
-                self._plugin._subscriptions[key].append(self)
         if news:
             yield from getattr(
                 self._sub,

--- a/muffin_redis.py
+++ b/muffin_redis.py
@@ -141,9 +141,10 @@ class Subscription():
         if not self._conn:
             raise ValueError('Was not connected')
         yield from self._conn.close()
+    @asyncio.coroutine
     def __aexit__(self, exc_type, exc, tb):
-        # this is not a coroutine but it returns a coroutine object
-        return self.close()
+        yield from self.close()
+        return None # reraise exception, if any
 
     @asyncio.coroutine
     def next_published(self):

--- a/muffin_redis.py
+++ b/muffin_redis.py
@@ -95,9 +95,8 @@ class Plugin(BasePlugin):
             message = jsonpickle.encode(message)
         return (yield from self.conn.publish(channel, message))
 
-    @asyncio.coroutine
-    def start_subscribe(self, *args):
-        # create separate connection
+    def start_subscribe(self):
+        # creates a context manager
         return Subscription(self)
 
     def __getattr__(self, name):
@@ -129,7 +128,7 @@ class Subscription():
                 password=cfg.password, db=cfg.db,
             ), cfg.timeout
         )
-        self._sub = (yield from self._conn.start_subscribe(*args))
+        self._sub = (yield from self._conn.start_subscribe())
         return self
     __aenter__ = open # alias
     @asyncio.coroutine

--- a/muffin_redis.py
+++ b/muffin_redis.py
@@ -124,8 +124,8 @@ class Subscription():
             if isinstance(msg.value, bytes):
                 msg._value = jsonpickle.decode(msg.value.decode('utf-8'))
             if isinstance(msg._value, str):
-                msg._value = jsonpickle.decode(ret.value)
-        return ret
+                msg._value = jsonpickle.decode(msg.value)
+        return msg
     @asyncio.coroutine
     def __aiter__(self):
         return self

--- a/tests.py
+++ b/tests.py
@@ -33,8 +33,7 @@ def test_muffin_redis(app):  # noqa
 
     # fakeredis seems to not support pub/sub, so disabling these test for now
     if False:
-        subscriber = yield from app.ps.redis.start_subscribe()
-        yield from subscriber.open()
+        subscriber = yield from app.ps.redis.start_subscribe().open()
         yield from subscriber.subscribe(['channel'])
         channels = yield from app.ps.redis.conn.pubsub_channels()
         assert 'channel' in channels

--- a/tests.py
+++ b/tests.py
@@ -32,28 +32,29 @@ def test_muffin_redis(app):  # noqa
     assert result is None
 
     # fakeredis seems to not support pub/sub, so disabling these test for now
-#    subscriber = yield from app.ps.redis.start_subscribe()
-#    yield from subscriber.subscribe(['channel'])
-#    channels = yield from app.ps.redis.conn.pubsub_channels()
-#    assert 'channel' in channels
-#
-#    yield from app.ps.publish('channel', 'Hello world')
-#    yield from app.ps.publish('channel', {
-#        'now': datetime.datetime.now(),
-#    })
-#
-#    result = yield from subscriber.next_published()
-#    assert result and result.value == 'Hello world'
-#
-#    # another way: iterator style
-#    #async for result in subscriber:
-#    #    value = result.value
-#    #    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
-#    #    break
-#    # -- but this test requires python 3.5, so for now use simplified syntax
-#    result = yield from subscriber.__anext__()
-#    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
-#
-#    yield from subscriber.unsubscribe()
-#    result = yield from app.ps.redis.conn.pubsub_channels()
-#    assert 'channel' not in result
+    if False:
+        subscriber = yield from app.ps.redis.start_subscribe()
+        yield from subscriber.subscribe(['channel'])
+        channels = yield from app.ps.redis.conn.pubsub_channels()
+        assert 'channel' in channels
+
+        yield from app.ps.publish('channel', 'Hello world')
+        yield from app.ps.publish('channel', {
+            'now': datetime.datetime.now(),
+        })
+
+        result = yield from subscriber.next_published()
+        assert result and result.value == 'Hello world'
+
+        # another way: iterator style
+        #async for result in subscriber:
+        #    value = result.value
+        #    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
+        #    break
+        # -- but this test requires python 3.5, so for now use simplified syntax
+        result = yield from subscriber.__anext__()
+        assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
+
+        yield from subscriber.unsubscribe()
+        result = yield from app.ps.redis.conn.pubsub_channels()
+        assert 'channel' not in result

--- a/tests.py
+++ b/tests.py
@@ -30,3 +30,26 @@ def test_muffin_redis(app):  # noqa
 
     result = yield from app.ps.redis.get('unknown')
     assert result is None
+
+    subscriber = yield from app.ps.redis.start_subscribe()
+    yield from subscriber.subscribe(['channel'])
+    channels = yield from app.ps.redis.conn.pubsub_channels()
+    assert 'channel' in channels
+
+    yield from app.ps.publish('channel', 'Hello world')
+    yield from app.ps.publish('channel', {
+        'now': datetime.datetime.now(),
+    })
+
+    result = yield from subscriber.next_published()
+    assert result and result.value == 'Hello world'
+
+    # another way: iterator style
+    async for result in subscriber:
+        value = result.value
+        assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
+        break
+
+    yield from subscriber.unsubscribe()
+    result = yield from app.ps.redis.conn.pubsub_channels()
+    assert 'channel' not in result

--- a/tests.py
+++ b/tests.py
@@ -31,28 +31,29 @@ def test_muffin_redis(app):  # noqa
     result = yield from app.ps.redis.get('unknown')
     assert result is None
 
-    subscriber = yield from app.ps.redis.start_subscribe()
-    yield from subscriber.subscribe(['channel'])
-    channels = yield from app.ps.redis.conn.pubsub_channels()
-    assert 'channel' in channels
-
-    yield from app.ps.publish('channel', 'Hello world')
-    yield from app.ps.publish('channel', {
-        'now': datetime.datetime.now(),
-    })
-
-    result = yield from subscriber.next_published()
-    assert result and result.value == 'Hello world'
-
-    # another way: iterator style
-    #async for result in subscriber:
-    #    value = result.value
-    #    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
-    #    break
-    # -- but this test requires python 3.5, so for now use simplified syntax
-    result = yield from subscriber.__anext__()
-    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
-
-    yield from subscriber.unsubscribe()
-    result = yield from app.ps.redis.conn.pubsub_channels()
-    assert 'channel' not in result
+    # fakeredis seems to not support pub/sub, so disabling these test for now
+#    subscriber = yield from app.ps.redis.start_subscribe()
+#    yield from subscriber.subscribe(['channel'])
+#    channels = yield from app.ps.redis.conn.pubsub_channels()
+#    assert 'channel' in channels
+#
+#    yield from app.ps.publish('channel', 'Hello world')
+#    yield from app.ps.publish('channel', {
+#        'now': datetime.datetime.now(),
+#    })
+#
+#    result = yield from subscriber.next_published()
+#    assert result and result.value == 'Hello world'
+#
+#    # another way: iterator style
+#    #async for result in subscriber:
+#    #    value = result.value
+#    #    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
+#    #    break
+#    # -- but this test requires python 3.5, so for now use simplified syntax
+#    result = yield from subscriber.__anext__()
+#    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
+#
+#    yield from subscriber.unsubscribe()
+#    result = yield from app.ps.redis.conn.pubsub_channels()
+#    assert 'channel' not in result

--- a/tests.py
+++ b/tests.py
@@ -45,10 +45,13 @@ def test_muffin_redis(app):  # noqa
     assert result and result.value == 'Hello world'
 
     # another way: iterator style
-    async for result in subscriber:
-        value = result.value
-        assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
-        break
+    #async for result in subscriber:
+    #    value = result.value
+    #    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
+    #    break
+    # -- but this test requires python 3.5, so for now use simplified syntax
+    result = yield from subscriber.__anext__()
+    assert value and 'now' in value and isinstance(value['now'], datetime.datetime)
 
     yield from subscriber.unsubscribe()
     result = yield from app.ps.redis.conn.pubsub_channels()

--- a/tests.py
+++ b/tests.py
@@ -34,6 +34,7 @@ def test_muffin_redis(app):  # noqa
     # fakeredis seems to not support pub/sub, so disabling these test for now
     if False:
         subscriber = yield from app.ps.redis.start_subscribe()
+        yield from subscriber.open()
         yield from subscriber.subscribe(['channel'])
         channels = yield from app.ps.redis.conn.pubsub_channels()
         assert 'channel' in channels
@@ -58,3 +59,5 @@ def test_muffin_redis(app):  # noqa
         yield from subscriber.unsubscribe()
         result = yield from app.ps.redis.conn.pubsub_channels()
         assert 'channel' not in result
+
+        yield from subscriber.close()


### PR DESCRIPTION
I have implemented a basic Pub/Sub support for this plugin.
Because plugin is shared across concurrent connections, and subscribe mode occupies Redis connection making it impossible to perform other commands on it, I chose to create new Redis connection for each subscription manager.
Later it can be optimized by using just one pubsub-specific Redis connection per plugin and multiplexing messages from it based on channel/mask, like suggested in [Redis docs](redis.io/topics/pubsub#client-library-implementation-hints)

Unfortunately I was unable to implement proper tests for pub/sub because `fakeredis` seems to not support pub/sub at all, at least in a way compatible with `asyncio-redis`.