### PR TITLE
Added workaround to wait for connections to be actually closed

### DIFF
--- a/muffin_redis.py
+++ b/muffin_redis.py
@@ -84,11 +84,16 @@ class Plugin(BasePlugin):
             except asyncio.TimeoutError:
                 raise PluginException('Muffin-redis connection timeout.')
 
+    @asyncio.coroutine
     def finish(self, app):
         """Close self connections."""
         self.conn.close()
         if self.pubsub_conn:
             self.pubsub_conn.close()
+        # give connections a chance to actually terminate
+        # TODO: use better method once it will be added,
+        # see https://github.com/jonathanslenders/asyncio-redis/issues/56
+        yield  # or: yield from asyncio.sleep(0)
 
     @asyncio.coroutine
     def set(self, key, value, *args, **kwargs):


### PR DESCRIPTION
This should fix #3, at least when there are no data pending at the moment of connection close